### PR TITLE
Change CompileTests to its new name: Test::Compile

### DIFF
--- a/lib/Dist/Zilla/PluginBundle/TestingMania.pm
+++ b/lib/Dist/Zilla/PluginBundle/TestingMania.pm
@@ -55,7 +55,7 @@ dist.
 
 =item *
 
-L<Dist::Zilla::Plugin::CriticTests>, which checks your code against best
+L<Dist::Zilla::Plugin::Test::Perl::Critic>, which checks your code against best
 practices. See L<Perl::Critic> for details. You can set a perlcritic config
 file:
 


### PR DESCRIPTION
require version 1.112400

See http://jquelin.blogspot.com/2011/08/great-renaming-distzillaplugincompilete.html

I didn't update README or Makefile.PL;
I assume they will be regenerated when you build.
